### PR TITLE
Change lists.sics.se links to https

### DIFF
--- a/xml/index.xml
+++ b/xml/index.xml
@@ -100,8 +100,8 @@
 	<h3>Mail</h3>
 
 	There are two mailings lists:
-	<a href="http://list.sics.se/sympa/info/heimdal-announce">heimdal-announce</a> and
-	<a href="http://list.sics.se/sympa/info/heimdal-discuss">heimdal-discuss</a>
+	<a href="https://list.sics.se/sympa/info/heimdal-announce">heimdal-announce</a> and
+	<a href="https://list.sics.se/sympa/info/heimdal-discuss">heimdal-discuss</a>
 	(<a href="https://list.sics.se/sympa/arc/heimdal-discuss">ml-archive</a>,
 	<a href="http://www.mail-archive.com/heimdal-discuss@sics.se/">mail-archive</a>,
 	<a href="http://news.gmane.org/gmane.comp.encryption.kerberos.heimdal.general">gmane</a>).

--- a/xml/info.xml
+++ b/xml/info.xml
@@ -26,8 +26,8 @@
 
       <p>
 	There are two mailings lists:
-	<a href="http://list.sics.se/sympa/info/heimdal-announce">heimdal-announce</a> and
-	<a href="http://list.sics.se/sympa/info/heimdal-discuss">heimdal-discuss</a>
+	<a href="https://list.sics.se/sympa/info/heimdal-announce">heimdal-announce</a> and
+	<a href="https://list.sics.se/sympa/info/heimdal-discuss">heimdal-discuss</a>
 	(<a href="http://www.stacken.kth.se/lists/heimdal-discuss/index.php">ml-archive</a>,
 	<a href="http://www.mail-archive.com/heimdal-discuss@sics.se/">mail-archive</a>,
 	<a href="http://news.gmane.org/gmane.comp.encryption.kerberos.heimdal.general">gmane</a>).


### PR DESCRIPTION
Their http to https redirect doesn't handle URLs gracefully which makes
the links go to their frontpage not the actual list.
