### PR TITLE
Version is 7.1.0, not 7.1.  Fixes broken download link

### DIFF
--- a/xml/heimdal.xml
+++ b/xml/heimdal.xml
@@ -610,7 +610,7 @@
 
     <release>
       <name>Heimdal</name>
-      <version>7.1</version>
+      <version>7.1.0</version>
       <date>2016-12-22</date>
       <major-changes>
 	<change>hcrypto is now thread safe on all platforms and as


### PR DESCRIPTION
For issue #8 